### PR TITLE
fix: update with correct URL to get the examples

### DIFF
--- a/bin/generate-examples.js
+++ b/bin/generate-examples.js
@@ -1,4 +1,4 @@
-const methods = require('./array-methods.json');
+const methods = require('../array-methods.json');
 const fetch = require('isomorphic-unfetch');
 
 // one that's missing
@@ -16,7 +16,7 @@ async function main() {
         method = 'reduce-right';
       }
 
-      return fetch(`${API}${method}.html`)
+      return fetch(`${API}${method}.js`)
         .then(res => {
           if (res.status === 404) {
             if (method === 'tosource') {


### PR DESCRIPTION
Fix the generate-examples.js utility
- [x] update methods path.
- [x] update the JS example URL to generate the examples.