### PR TITLE
Fix copyWithin incorrectly showing 'no mutation'

### DIFF
--- a/mutators.json
+++ b/mutators.json
@@ -7,5 +7,5 @@
   "splice",
   "reverse",
   "fill",
-  "copywithin"
+  "copyWithin"
 ]

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "scripts": {
     "dev": "DEBUG=-11ty* eleventy --serve",
-    "build": "eleventy"
+    "build": "eleventy",
+    "test": "node test/mutators.mjs"
   },
   "keywords": [],
   "author": "Remy Sharp",

--- a/test/mutators.mjs
+++ b/test/mutators.mjs
@@ -1,0 +1,14 @@
+import mutators from '../mutators.json' with { type: 'json' };
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+describe('mutators', async () => {
+  for (const method of mutators) {
+    it(`${method} should be a method of Array.prototype`, async () => {
+      assert(
+        typeof Array.prototype[method] === 'function',
+        `"${method}" is not method of Array.prototype`,
+      );
+    });
+  }
+});


### PR DESCRIPTION
Equality check was failing due to wrong capitalization.